### PR TITLE
Alter scheduling code to accept 1.5 schedules

### DIFF
--- a/ChildToNPC/ModEntry.cs
+++ b/ChildToNPC/ModEntry.cs
@@ -107,14 +107,12 @@ namespace ChildToNPC
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.checkSchedule)),
                 prefix: new HarmonyMethod(typeof(Patches.NPCCheckSchedulePatch), nameof(Patches.NPCCheckSchedulePatch.Prefix))
             );
-            // NPC.parseMasterSchedule patch (prefix & postfix)
+            // NPC.parseMasterSchedule patch (prefix, postfix, finalizer)
             harmony.Patch(
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.parseMasterSchedule)),
-                prefix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Prefix))
-            );
-            harmony.Patch(
-                original: AccessTools.Method(typeof(NPC), nameof(NPC.parseMasterSchedule)),
-                postfix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Postfix))
+                prefix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Prefix)),
+                postfix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Postfix)),
+                finalizer: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Finalizer))
             );
             // NPC.prepareToDisembarkOnNewSchedulePath patch (postfix)
             harmony.Patch(
@@ -466,13 +464,11 @@ namespace ChildToNPC
          */
         public static bool IsChildNPC(Character c)
         {
-            //ModEntry.monitor.Log($"copies: {copies?.Count}", LogLevel.Error);
             return (copies != null && copies.ContainsValue(c as NPC));
         }
 
         public static bool IsChildNPC(NPC npc)
         {
-            //ModEntry.monitor.Log($"copies: {copies?.Count}", LogLevel.Error); 
             return (copies != null && copies.ContainsValue(npc));
         }
 

--- a/ChildToNPC/ModEntry.cs
+++ b/ChildToNPC/ModEntry.cs
@@ -107,13 +107,13 @@ namespace ChildToNPC
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.checkSchedule)),
                 prefix: new HarmonyMethod(typeof(Patches.NPCCheckSchedulePatch), nameof(Patches.NPCCheckSchedulePatch.Prefix))
             );
-            // NPC.parseMasterSchedule patch (prefix)
+            // NPC.parseMasterSchedule patch (prefix & postfix)
             harmony.Patch(
-                original: AccessTools.Method(typeof(NPC), "parseMasterSchedule"),
+                original: AccessTools.Method(typeof(NPC), nameof(NPC.parseMasterSchedule)),
                 prefix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(NPC), "parseMasterSchedule"),
+                original: AccessTools.Method(typeof(NPC), nameof(NPC.parseMasterSchedule)),
                 postfix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Postfix))
             );
             // NPC.prepareToDisembarkOnNewSchedulePath patch (postfix)
@@ -303,7 +303,7 @@ namespace ChildToNPC
         /// <param name="child">The child to check.</param>
         public static bool IsOldEnough(Child child)
         {
-            return child.daysOld >= Config.AgeWhenKidsAreModified;
+            return child.daysOld.Value >= Config.AgeWhenKidsAreModified;
         }
 
         /// <summary>Get all children, including those who haven't been converted into NPCs.</summary>

--- a/ChildToNPC/ModEntry.cs
+++ b/ChildToNPC/ModEntry.cs
@@ -112,6 +112,10 @@ namespace ChildToNPC
                 original: AccessTools.Method(typeof(NPC), "parseMasterSchedule"),
                 prefix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Prefix))
             );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NPC), "parseMasterSchedule"),
+                postfix: new HarmonyMethod(typeof(Patches.NPCParseMasterSchedulePatch), nameof(Patches.NPCParseMasterSchedulePatch.Postfix))
+            );
             // NPC.prepareToDisembarkOnNewSchedulePath patch (postfix)
             harmony.Patch(
                 original: AccessTools.Method(typeof(NPC), "prepareToDisembarkOnNewSchedulePath"),
@@ -275,7 +279,7 @@ namespace ChildToNPC
             {
                 if (c.daysOld.Value < 54)
                     c.daysOld.Value = 54;
-                Monitor.Log(childName + " is now " + c.daysOld + " days old.");
+                Monitor.Log(childName + " is now " + c.daysOld.Value + " days old.");
             }
             else
             {
@@ -462,11 +466,13 @@ namespace ChildToNPC
          */
         public static bool IsChildNPC(Character c)
         {
+            //ModEntry.monitor.Log($"copies: {copies?.Count}", LogLevel.Error);
             return (copies != null && copies.ContainsValue(c as NPC));
         }
 
         public static bool IsChildNPC(NPC npc)
         {
+            //ModEntry.monitor.Log($"copies: {copies?.Count}", LogLevel.Error); 
             return (copies != null && copies.ContainsValue(npc));
         }
 

--- a/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
+++ b/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
@@ -2,7 +2,6 @@
 using StardewValley;
 using StardewModdingAPI;
 
-#nullable enable
 namespace ChildToNPC.Patches
 {
 
@@ -43,7 +42,7 @@ namespace ChildToNPC.Patches
             // For a Child2NPC, this is always the bus stop, so I can just do the replacement here
             if (rawData.EndsWith("bed"))
             {
-                rawData = rawData.Replace("bed", "BusStop -1 23 3");
+                rawData = rawData[..^3] + "BusStop -1 23 3";
             }
 
             // Save the previous default map and default position.
@@ -74,5 +73,3 @@ namespace ChildToNPC.Patches
         }
     }
 }
-
-#nullable disable

--- a/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
+++ b/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
@@ -79,7 +79,10 @@ namespace ChildToNPC.Patches
         /// <param name="__exception">The exception thrown.</param>
         public static void Finalizer(NPC __instance, Exception __exception)
         {
-            __instance.reloadDefaultLocation();
+            if (__exception is not null)
+            {
+                __instance.reloadDefaultLocation();
+            }
         }
     }
 }

--- a/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
+++ b/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewModdingAPI;
+using System;
 
 namespace ChildToNPC.Patches
 {
@@ -33,7 +34,6 @@ namespace ChildToNPC.Patches
         {
             if (!ModEntry.IsChildNPC(__instance))
             {
-                ModEntry.monitor.Log(__instance.Name, LogLevel.Warn);
                 __state = null;
                 return;
             }
@@ -70,6 +70,16 @@ namespace ChildToNPC.Patches
                 __instance.DefaultMap = __state.defaultMap;
                 __instance.DefaultPosition = __state.defaultPosition;
             }
+        }
+
+        /// <summary>
+        /// Error handling - if parseMasterSchedule throws an error, refreshes the default location/
+        /// </summary>
+        /// <param name="__instance">NPC in question</param>
+        /// <param name="__exception">The exception thrown.</param>
+        public static void Finalizer(NPC __instance, Exception __exception)
+        {
+            __instance.reloadDefaultLocation();
         }
     }
 }

--- a/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
+++ b/ChildToNPC/Patches/NPCParseMasterSchedulePatch.cs
@@ -1,198 +1,78 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using StardewValley;
-using StardewValley.Network;
+using StardewModdingAPI;
 
+#nullable enable
 namespace ChildToNPC.Patches
 {
-    /* Prefix for parseMasterSchedule
-     * Most of this code is directly translated from the original method,
-     * and there are extra methods at the bottom which are recreating what the original does.
-     * (I'd like to come back to this and see if I can find a better solution).
-     * The parts I need to change are mixed in, so I have to re-execute most code.
-     */
+
+    public class DefaultLocation
+    {
+        public string defaultMap { get; set; }
+        public Vector2 defaultPosition { get; set; }
+
+        public DefaultLocation(string defaultMap, Vector2 defaultPosition)
+        {
+            this.defaultMap = defaultMap;
+            this.defaultPosition = defaultPosition;
+        }
+    }
+
+    /// <summary>
+    /// Class that holds patches against parseMasterSchedule
+    /// </summary>
+    /// <remarks>Assign the Child2NPC a fake start location to match the default start location of spouses.</remarks>
     class NPCParseMasterSchedulePatch
     {
-        public static bool Prefix(NPC __instance, ref Dictionary<int, SchedulePathDescription> __result, string rawData,
-            List<List<string>> ___routesFromLocationToLocation)
+        /// <summary>
+        /// Handles `bed` before the vanilla function can, assigns Child2NPC a fake start location.
+        /// </summary>
+        /// <param name="__instance">NPC</param>
+        /// <param name="rawData">Raw schedule string.</param>
+        /// <param name="__state">Holds default start location, to restore later.</param>
+        public static void Prefix(NPC __instance, ref string rawData, out DefaultLocation? __state)
         {
             if (!ModEntry.IsChildNPC(__instance))
-                return true;
-
-            string[] events = rawData.Split('/');
-            int index = 0;
-            Dictionary<int, SchedulePathDescription> dictionary = new Dictionary<int, SchedulePathDescription>();
-
-            Dictionary<string, string> scheduleFromName = null;
-            try
             {
-                scheduleFromName = Game1.content.Load<Dictionary<string, string>>("Characters\\schedules\\" + __instance.Name);
+                ModEntry.monitor.Log(__instance.Name, LogLevel.Warn);
+                __state = null;
+                return;
             }
-            catch (Exception e)
+            
+            // Scheduling code can use "bed" to refer to the usual last stop of an NPC
+            // For a Child2NPC, this is always the bus stop, so I can just do the replacement here
+            if (rawData.EndsWith("bed"))
             {
-                ModEntry.monitor.Log("An error occurred in ParseMasterSchedule while trying to load the schedule for " + __instance.Name + ": " + e.Message);
-                return true;
+                rawData = rawData.Replace("bed", "BusStop -1 23 3");
             }
 
-            //Example: "GOTO Tue" or "GOTO spring" says which entry to use
-            //This replaces the rawData with whatever entry the GOTO requested
-            if (events[0].Contains("GOTO"))
+            // Save the previous default map and default position.
+            __state = new DefaultLocation(
+                defaultMap: __instance.DefaultMap,
+                defaultPosition: __instance.DefaultPosition);
+
+            // Pretending my start location is the bus stop location.
+            __instance.DefaultMap = "BusStop";
+            __instance.DefaultPosition = new Vector2(0,23)*64;
+
+            return;
+        }
+
+        /// <summary>
+        /// Restore default map and position.
+        /// </summary>
+        /// <param name="__instance">NPC</param>
+        /// <param name="rawData">Raw schedule string.</param>
+        /// <param name="__state">Default location for NPC, saved from prefix.</param>
+        public static void Postfix(NPC __instance, string rawData, DefaultLocation? __state)
+        {
+            if (__state is not null)
             {
-                string whereToGo = events[0].Split(' ')[1];
-                if (whereToGo.ToLower().Equals("season"))
-                    whereToGo = Game1.currentSeason;
-                try
-                {
-                    events = scheduleFromName[whereToGo].Split('/');
-                }
-                catch (Exception)
-                {
-                    __result = ModEntry.helper.Reflection.GetMethod(__instance, "parseMasterSchedule", true).Invoke<Dictionary<int, SchedulePathDescription>>(new object[] { scheduleFromName["spring"] });
-                    return false;
-                }
+                __instance.DefaultMap = __state.defaultMap;
+                __instance.DefaultPosition = __state.defaultPosition;
             }
-
-            //Example: "NOT friendship Sam 6/" as first entry
-            //Tells you to skip this entry if the friendship isn't set
-            if (events[0].Contains("NOT"))
-            {
-                string[] friendshipData = events[0].Split(' ');
-                if (friendshipData[1].ToLower() == "friendship")
-                {
-                    string name = friendshipData[2];
-                    int hearts = Convert.ToInt32(friendshipData[3]);
-                    bool farmerHasHearts = false;
-                    foreach (Farmer allFarmer in Game1.getAllFarmers())
-                    {
-                        if (allFarmer.getFriendshipLevelForNPC(name) >= hearts)
-                        {
-                            farmerHasHearts = true;
-                            break;
-                        }
-                    }
-
-                    if (!farmerHasHearts)
-                    {
-                        __result = ModEntry.helper.Reflection.GetMethod(__instance, "parseMasterSchedule", true).Invoke<Dictionary<int, SchedulePathDescription>>(new object[] { scheduleFromName["spring"] });
-                        return false;
-                    }
-                    //Otherwise, increment index by 1, continue with schedule
-                    ++index;
-                }
-            }
-            //Added in the 1.4 update, I haven't checked this dialogue yet
-            else if (events[0].Contains("MAIL"))
-            {
-                string id = events[0].Split(' ')[1];
-                if (Game1.MasterPlayer.mailReceived.Contains(id) || NetWorldState.checkAnywhereForWorldStateID(id))
-                    index += 2;
-                else
-                    ++index;
-            }
-
-            //For the case of "NOT friendship Sam 6/GOTO 9" (I think)
-            //Handles the GOTO if friendship change happened
-            if (events[index].Contains("GOTO"))
-            {
-                string whereToGo = events[index].Split(' ')[1];
-                if (whereToGo.ToLower().Equals("season"))
-                    whereToGo = Game1.currentSeason;
-                else if (whereToGo.ToLower().Equals("no_schedule"))
-                {
-                    __instance.followSchedule = false;
-                    __result = null;
-                    return false;
-                }
-                events = scheduleFromName[whereToGo].Split('/');
-                index = 1;
-            }
-
-            //Point point = this.isMarried() ? new Point(0, 23) : new Point((int)this.defaultPosition.X / 64, (int)this.defaultPosition.Y / 64);
-            //string startingLocation = this.isMarried() ? "BusStop" : (string)((NetFieldBase<string, NetString>)this.defaultMap);
-            Point point = new Point(0, 23);
-            string startingLocation = "BusStop";
-
-            //Go through each of the events, parse them.
-            for (int i = index; i < events.Length/* && events.Length > 1*/; ++i)
-            {
-                string[] currentEvent = events[i].Split(' ');
-
-                int time = Convert.ToInt32(currentEvent[0]);
-                string locationName = currentEvent[1];
-                string endBehavior = null;
-                string endMessage = null;
-
-                //If there is no location name, skips straight to position
-                if (int.TryParse(locationName, out int result))
-                    locationName = startingLocation;
-
-                // Provide a meaningful error message: Convert.ToInt32() would throw as well
-                // but won't give us any details about the unconvertible string.
-                int positionX;
-                if (!int.TryParse(currentEvent[2], out positionX))
-                {
-                    throw new ArgumentException($"Couldn't parse string as int: {currentEvent[2]}");
-                }
-
-                int positionY;
-                if (!int.TryParse(currentEvent[3], out positionY))
-                {
-                    throw new ArgumentException($"Couldn't parse string as int: {currentEvent[3]}");
-                }
-
-                int endIndex = 4;
-                int facingDirection;
-
-                try
-                {
-                    facingDirection = Convert.ToInt32(currentEvent[4]);
-                    ++endIndex;
-                }
-                catch (Exception)
-                {
-                    facingDirection = 2;
-                }
-
-                object[] param = { locationName, positionX, positionY, facingDirection };
-                bool accessibleChange = ModEntry.helper.Reflection.GetMethod(__instance, "changeScheduleForLocationAccessibility", true).Invoke<bool>(param);
-
-                if (accessibleChange)
-                {
-                    if (scheduleFromName.ContainsKey("default"))
-                    {
-                        __result = ModEntry.helper.Reflection.GetMethod(__instance, "parseMasterSchedule", true).Invoke<Dictionary<int, SchedulePathDescription>>(new object[] { scheduleFromName["default"] });
-                        return false;
-                    }
-                    __result = ModEntry.helper.Reflection.GetMethod(__instance, "parseMasterSchedule", true).Invoke<Dictionary<int, SchedulePathDescription>>(new object[] { scheduleFromName["spring"] });
-                    return false;
-                }
-
-                //830 ArchaeologyHouse 17 9 2 penny_read \"Strings\\schedules\\Penny:marriageJob.000\"
-                if (currentEvent.Length > endIndex)
-                {
-                    if (currentEvent[endIndex].Length > 0 && currentEvent[endIndex][0] == '"')
-                    {
-                        endMessage = events[i].Substring(events[i].IndexOf('"'));
-                    }
-                    else
-                    {
-                        endBehavior = currentEvent[endIndex];
-                        if (endIndex + 1 < currentEvent.Length && currentEvent[endIndex + 1].Length > 0 && currentEvent[endIndex + 1][0] == '"')
-                            endMessage = events[i].Substring(events[i].IndexOf('"')).Replace("\"", "");
-                    }
-                }
-
-                //Add this time event to the dictionary
-                dictionary.Add(time, ModEntry.helper.Reflection.GetMethod(__instance, "pathfindToNextScheduleLocation", true).Invoke<SchedulePathDescription>(new object[] { startingLocation, point.X, point.Y, locationName, positionX, positionY, facingDirection, endBehavior, endMessage }));
-                //Then pretend this character has completed that appt, check next appt
-                point.X = positionX;
-                point.Y = positionY;
-                startingLocation = locationName;
-            }
-
-            __result = dictionary;
-            return false;
         }
     }
 }
+
+#nullable disable


### PR DESCRIPTION
Currently, when a Child2NPC is given a schedule that includes either arrival times or the `bed` location, it causes an exception within parseMasterSchedule. (See log here: https://smapi.io/log/454648bae47145d1ab4e540b507a7df7)

I actually don't think Child2NPC needs to rewrite the scheduling code at all - it'll generate valid schedules for the Child2NPCs just by temporarily setting their default location to BusStop 0 23, which is the approach I took here. I think this is more future-proofed because it duplicates less code.